### PR TITLE
Check

### DIFF
--- a/src/lib/libhaproxy.py
+++ b/src/lib/libhaproxy.py
@@ -150,10 +150,9 @@ class ProxyHelper():
             # nicer HTTP checks for HTTP backends will also
             # be enabled to perform HTTP requests as part of
             # checking backend health
+            attributes = []
             if config['check']:
                 attributes = ['check fall 3 rise 2']
-            else:
-                attributes = []
 
             # Add server to the backend
             # Firstly, set the mode on the backedn to match

--- a/src/lib/libhaproxy.py
+++ b/src/lib/libhaproxy.py
@@ -150,7 +150,8 @@ class ProxyHelper():
             # nicer HTTP checks for HTTP backends will also
             # be enabled to perform HTTP requests as part of
             # checking backend health
-            attributes = ['check fall 3 rise 2']
+            if config['check']:
+                attributes = ['check fall 3 rise 2']
 
             # Add server to the backend
             # Firstly, set the mode on the backedn to match

--- a/src/lib/libhaproxy.py
+++ b/src/lib/libhaproxy.py
@@ -152,6 +152,8 @@ class ProxyHelper():
             # checking backend health
             if config['check']:
                 attributes = ['check fall 3 rise 2']
+            else:
+                attributes = []
 
             # Add server to the backend
             # Firstly, set the mode on the backedn to match

--- a/src/tests/unit/conftest.py
+++ b/src/tests/unit/conftest.py
@@ -15,7 +15,8 @@ def config():
                 'group_id': None,
                 'external_port': 80,
                 'internal_host': 'test-host',
-                'internal_port': 8000
+                'internal_port': 8000,
+                'check': True,
                 }
     return defaultdict(lambda: None, defaults)
 

--- a/src/tests/unit/test_libhaproxy.py
+++ b/src/tests/unit/test_libhaproxy.py
@@ -101,6 +101,12 @@ class TestLibhaproxy():
                 rewrite_found = True
         assert rewrite_found
         assert backend.acl('local')
+        check_found = False
+        for server in backend.servers():
+            for attribute in server.attributes:
+                if 'check' in attribute:
+                    check_found = True
+        assert check_found
 
         # Add a unit with proxypass, ssl verify none, and no check
         monkeypatch.setattr('libhaproxy.hookenv.remote_unit', lambda: 'unit-mock/8')
@@ -113,6 +119,7 @@ class TestLibhaproxy():
         config['ssl'] = True
         config['ssl-verify'] = False
         config['external_port'] = 443
+        config['check'] = False
         assert ph.process_configs([config])['cfg_good'] is True
         backend = ph.get_backend('unit-mock-8-0', create=False)
         forward_for_found = False
@@ -130,6 +137,12 @@ class TestLibhaproxy():
             if 'ssl verify none' in server.attributes:
                 ssl_found = True
         assert ssl_found
+        check_found = False
+        for server in backend.servers():
+            for attribute in server.attributes:
+                if 'check' in attribute:
+                    check_found = True
+        assert not check_found
 
         # Check that the expected number of backends are in use
         # Backends 0-0,0-1,2,3,4,5,6,7 should be in use by HTTP port 80


### PR DESCRIPTION
This puts the default check behind a feature flag and defaults that flag from the interface to True so it matches current function. The way this is implemented the default value is set in the interface, new charms will just work as expected but existing charms will not get the check until they are rebuilt with the new interface.

That's not ideal, but I didn't really like the idea of enabling 'disable check' and thought it was worth rebuilding a charm or two so that the interface was a bit cleaner. I just wanted to open this for feedback, if this is how we proceed I want to push the change to interface-reverseproxy and then update this branch to use the master branch before merging.

Changes are to the interface, the config file processing, and unit tests.