### PR TITLE
Opportunistically use HTTP/2, and bump default to Haproxy 1.9

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,11 +1,15 @@
 options:
   version:
     type: string
-    default: "1.7"
+    default: "1.9"
     description: "Version of HAProxy to install"
+  enable-http2:
+    type: boolean
+    default: true
+    description: "Enable HTTP2 is HTTPS is enabled and at least version 1.9 is installed."
   enable-stats:
     type: boolean
-    default: True
+    default: true
     description: "Enable HAProxy stats page"
   stats-user:
     type: string
@@ -25,7 +29,7 @@ options:
     description: "Port for accessing stats page"
   stats-local:
     type: boolean
-    default: True
+    default: true
     description: "Restrict stats to local IP ranges"
   cert-renew-interval:
     type: string
@@ -37,9 +41,9 @@ options:
     description: "Cron interval to rewnew upnp, if in use"
   destination-https-rewrite:
     type: boolean
-    default: True
+    default: true
     description: "Rewrite 'Destination' header so WebDav servers wont fail on mismatched file paths (http vs https)"
   enable-https-redirect:
     type: boolean
-    default: True
+    default: true
     description: "Redirect http requets with no explicit backend to https"

--- a/tests/functional/test_deploy.py
+++ b/tests/functional/test_deploy.py
@@ -12,7 +12,6 @@ pytestmark = pytest.mark.asyncio
 juju_repository = os.getenv('JUJU_REPOSITORY', '.').rstrip('/')
 series = ['xenial',
           pytest.param('bionic', marks=pytest.mark.xfail(reason='canary')),
-          pytest.param('cosmic', marks=pytest.mark.xfail(reason='canary')),
           ]
 sources = [('local', '{}/builds/haproxy'.format(juju_repository)),
            ('jujucharms', 'cs:~pirate-charmers/haproxy'),


### PR DESCRIPTION
This merge will allow HTTP/2 to be used on HTTPS frontends. Backends still use HTTP/1.1. This will only be enabled if version 1.9 or higher is configured. This change also bumps to 1.9, which I have been running in my "production" environment for months without issue using the current charm.