### PR TITLE
Testing fixes, and added TCP+TLS TLS termination for TCP frontends

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ submodules:
 
 lint:
 	@echo "Running flake8"
-	@-tox -e lint
+	@-tox -e lintverbose
 
 test: lint unittest functional
 

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,3 +1,4 @@
+---
 includes:
   - layer:basic
   - layer:version
@@ -8,4 +9,6 @@ includes:
 options:
   version:
     file_name: "repo-info"
+ignore:
+  - operator_requires.py
 repo: https://github.com/pirate-charmers/layer-haproxy

--- a/tests/functional/test_deploy.py
+++ b/tests/functional/test_deploy.py
@@ -88,6 +88,9 @@ async def test_charm_upgrade(model, app):
     if app.name.endswith("local"):
         pytest.skip("No need to upgrade the local deploy")
     unit = app.units[0]
+    # check if version is on the charm store
+    if app.status == 'error':
+        pytest.skip("Not possible to upgrade errored canary versions")
     await model.block_until(lambda: unit.agent_status == "idle")
     subprocess.check_call(
         [

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist = unit, functional
+envlist = lintverbose, unit, functional
 skip_missing_interpreters = True
 
 [testenv]
@@ -52,6 +52,14 @@ deps =
     flake8-colors
     flake8-docstrings
     flake8-html
+    pep8-naming
+
+[testenv:lintverbose]
+commands = flake8 --max-complexity=40
+deps =
+    flake8
+    flake8-colors
+    flake8-docstrings
     pep8-naming
 
 [testenv:lintjunit]


### PR DESCRIPTION
Per alchemy-charmers/interface-reverseproxy#4 - this change adds support for arbitrary TCP frontends which also support TLS termination. This is supported by the TLS spec and is useful to TLS-terminating applications which don't have their own encryption support.

I've attempted to cover all the possible cases I can with unit tests, and the tests are passing. The intended outcome, is that if a TCP+TLS mode backend is connected, a TCP mode frontend will be created or updated for that port to use the TLS certs provided by letsencrypt, but only if it is enabled. Otherwise, it should just use TCP mode with no SSL CRT attribute on the frontend. I have units tests for adding and removing letsencrypt certs and frontends and all seems to work as intended.
